### PR TITLE
tf2 migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,12 @@ add_compile_options(-std=c++11)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   rviz_visual_tools
-  eigen_conversions
+  tf2_eigen
   geometry_msgs
   moveit_ros_robot_interaction
   moveit_core
   roscpp
-  tf_conversions
+  tf2_ros
   visualization_msgs
   graph_msgs
   std_msgs

--- a/package.xml
+++ b/package.xml
@@ -17,12 +17,12 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>rviz_visual_tools</depend>
-  <depend>eigen_conversions</depend>
+  <depend>tf2_eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>moveit_ros_robot_interaction</depend>
   <depend>moveit_core</depend>
   <depend>roscpp</depend>
-  <depend>tf_conversions</depend>
+  <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
   <depend>graph_msgs</depend>
   <depend>std_msgs</depend>

--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -93,8 +93,8 @@ bool MoveItVisualTools::loadPlanningSceneMonitor()
   ROS_DEBUG_STREAM_NAMED(name_, "Loading planning scene monitor");
 
   // Create tf transform buffer and listener
-  boost::shared_ptr<tf2_ros::Buffer> tf_buffer = boost::make_shared<tf2_ros::Buffer>();
-  boost::shared_ptr<tf2_ros::TransformListener> tf_listener = boost::make_shared<tf2_ros::TransformListener>(*tf_buffer);
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer = std::make_shared<tf2_ros::Buffer>();
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer);
 
   // Regular version b/c the other one causes problems with recognizing end effectors
   psm_.reset(new planning_scene_monitor::PlanningSceneMonitor(ROBOT_DESCRIPTION, tf_buffer, "visual_tools_scene"));


### PR DESCRIPTION
All conversions from `eigen_conversions` are now using `tf2_eigen` instead. `tf::TransformListener` is now converted to a combination of `tf2_ros::Buffer` and `tf2_ros::TransformListener`.

These **changes are for `melodic-devel` only**, and depend on https://github.com/ros-planning/moveit/pull/830.
