### PR TITLE
triggering UPDATE_GEOMETRY is sufficient, dont spinOnce

### DIFF
--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -189,10 +189,8 @@ bool MoveItVisualTools::moveCollisionObject(const geometry_msgs::Pose& pose, con
 bool MoveItVisualTools::triggerPlanningSceneUpdate()
 {
   // TODO(davetcoleman): perhaps switch to using the service call?
-  getPlanningSceneMonitor()->triggerSceneUpdateEvent(planning_scene_monitor::PlanningSceneMonitor::UPDATE_SCENE);
-  // getPlanningSceneMonitor()->triggerSceneUpdateEvent(planning_scene_monitor::PlanningSceneMonitor::UPDATE_GEOMETRY);
+  getPlanningSceneMonitor()->triggerSceneUpdateEvent(planning_scene_monitor::PlanningSceneMonitor::UPDATE_GEOMETRY);
 
-  ros::spinOnce();
   return true;
 }
 


### PR DESCRIPTION
We are currently investigating a massive slowdown in our code after some changes that should have led to speedups. One of the sources is that moveit_visual_tools triggers to many full updates in PlanningSceneMonitor. Another one is that it calls ros::spinOnce() afterwards, processing those updates directly in this thread (instead of a separate async spinner thread.

- triggering UPDATE_SCENE leads to sending a full planning scene including all meshes. For all use-cases in this lib UPDATE_GEOMETRY is sufficient and sends only diffs

- calling ros::spinOnce() in random places messes up the event queue (e.g. joint state updates being processed in gui thread instead of the async spinner thread)