### PR TITLE
Highlight selected links in publishRobotState() + improved collision visualization

### DIFF
--- a/include/moveit_visual_tools/moveit_visual_tools.h
+++ b/include/moveit_visual_tools/moveit_visual_tools.h
@@ -486,6 +486,21 @@ public:
   bool publishWorkspaceParameters(const moveit_msgs::WorkspaceParameters& params);
 
   /**
+   * \brief Check if the robot state is in collision inside the planning scene and visualize the result.
+   * If the state is not colliding only the robot state is published. If there is a collision the colliding
+   * links are ghlighted and the contact points are visualized with markers.
+   * \param robot_state - The robot state to check for collisions
+   * \param planning_scene - The planning scene to use for collision checks
+   * \param highlight_link_color - The color to use for highligting colliding links
+   * \param contact_point_color - The color to use for contact point markers
+   * \result - True if there is a collision
+   */
+  bool checkAndPublishCollision(const moveit::core::RobotState& robot_state,
+                                const planning_scene::PlanningScene* planning_scene,
+                                const rviz_visual_tools::colors& highlight_link_color = rviz_visual_tools::RED,
+                                const rviz_visual_tools::colors& contact_point_color = rviz_visual_tools::PURPLE);
+
+  /**
    * \brief Given a planning scene and robot state, publish any collisions
    * \param robot_state
    * \param planning_scene
@@ -493,6 +508,17 @@ public:
    * \return true on success
    */
   bool publishContactPoints(const moveit::core::RobotState& robot_state,
+                            const planning_scene::PlanningScene* planning_scene,
+                            const rviz_visual_tools::colors& color = rviz_visual_tools::RED);
+
+  /**
+   * \brief Given a contact map and planning scene, publish the contact points
+   * \param contacts - The populated contacts to visualize
+   * \param planning_scene
+   * \param color - display color of markers
+   * \return true on success
+   */
+  bool publishContactPoints(const collision_detection::CollisionResult::ContactMap& contacts,
                             const planning_scene::PlanningScene* planning_scene,
                             const rviz_visual_tools::colors& color = rviz_visual_tools::RED);
 

--- a/include/moveit_visual_tools/moveit_visual_tools.h
+++ b/include/moveit_visual_tools/moveit_visual_tools.h
@@ -607,7 +607,7 @@ public:
    *        To use, add a RobotState marker to Rviz and subscribe to the DISPLAY_ROBOT_STATE_TOPIC, above
    * \param robot_state - joint values of robot
    * \param color - how to highlight the robot (solid-ly) if desired, default keeps color as specified in URDF
-   * \param highlight_inks - names of robot link to highlight, by default (empty) all links are highlighted
+   * \param highlight_links - if the |color| is not |DEFAULT|, allows selective robot links to be highlighted. by default (empty) all links are highlighted 
    */
   bool publishRobotState(const moveit::core::RobotState& robot_state,
                          const rviz_visual_tools::colors& color = rviz_visual_tools::DEFAULT,

--- a/include/moveit_visual_tools/moveit_visual_tools.h
+++ b/include/moveit_visual_tools/moveit_visual_tools.h
@@ -607,11 +607,14 @@ public:
    *        To use, add a RobotState marker to Rviz and subscribe to the DISPLAY_ROBOT_STATE_TOPIC, above
    * \param robot_state - joint values of robot
    * \param color - how to highlight the robot (solid-ly) if desired, default keeps color as specified in URDF
+   * \param highlight_inks - names of robot link to highlight, by default (empty) all links are highlighted
    */
   bool publishRobotState(const moveit::core::RobotState& robot_state,
-                         const rviz_visual_tools::colors& color = rviz_visual_tools::DEFAULT);
+                         const rviz_visual_tools::colors& color = rviz_visual_tools::DEFAULT,
+                         const std::vector<std::string>& highlight_links = {});
   bool publishRobotState(const moveit::core::RobotStatePtr& robot_state,
-                         const rviz_visual_tools::colors& color = rviz_visual_tools::DEFAULT);
+                         const rviz_visual_tools::colors& color = rviz_visual_tools::DEFAULT,
+                         const std::vector<std::string>& highlight_links = {});
 
   /**
    * \brief Fake removing a Robot State display in Rviz by simply moving it very far away

--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -1405,7 +1405,7 @@ bool MoveItVisualTools::publishRobotState(const robot_state::RobotState& robot_s
                                           const rviz_visual_tools::colors& color,
                                           const std::vector<std::string>& highlight_links)
 {
-  // when only a subset of links should be colored, the default message is used
+  // when only a subset of links should be colored, the default message is used rather than the cached solid robot messages
   rviz_visual_tools::colors base_color = color;
   if (!highlight_links.empty())
     base_color = rviz_visual_tools::DEFAULT;


### PR DESCRIPTION
The current implementation of `publishRobotState()` allows coloring all links with a specific color.
This PR adds an optional argument `highlight_links` for specifying only a set of link names that should be highlighted with the given color. One example scenario would be to highligh links if they are in collision.

I'm also thinking of adding another function `visualizeCollisionResult()` or even `checkCollision()` that runs a collision check and then highlights the colliding links and publishes contact points using `publishContactPoints()`.

**UPDATE** - I extended this PR
* adds `checkAndPublishCollision()` for performing collision checks and highlighting the results
* adds publishContactPoints() that allows passing `CollisionResult::ContactMap` which allows visualizing contact points for already performed collision checks
