### PR TITLE
Use first trajectory point as start state for visualization

### DIFF
--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -1175,7 +1175,12 @@ bool MoveItVisualTools::publishTrajectoryPath(const std::vector<robot_state::Rob
   moveit_msgs::RobotTrajectory trajectory_msg;
   robot_trajectory->getRobotTrajectoryMsg(trajectory_msg);
 
-  return publishTrajectoryPath(trajectory_msg, shared_robot_state_, blocking);
+  // Use first trajectory point as reference state
+  moveit_msgs::RobotState robot_state_msg;
+  if (!trajectory.empty())
+    robot_state::robotStateToRobotStateMsg(*trajectory[0], robot_state_msg);
+
+  return publishTrajectoryPath(trajectory_msg, robot_state_msg, blocking);
 }
 
 bool MoveItVisualTools::publishTrajectoryPath(const robot_trajectory::RobotTrajectoryPtr& trajectory, bool blocking)
@@ -1200,7 +1205,12 @@ bool MoveItVisualTools::publishTrajectoryPath(const robot_trajectory::RobotTraje
     }
   }
 
-  return publishTrajectoryPath(trajectory_msg, shared_robot_state_, blocking);
+  // Use first trajectory point as reference state
+  moveit_msgs::RobotState robot_state_msg;
+  if (!trajectory.empty())
+    robot_state::robotStateToRobotStateMsg(trajectory.getFirstWayPoint(), robot_state_msg);
+
+  return publishTrajectoryPath(trajectory_msg, robot_state_msg, blocking);
 }
 
 bool MoveItVisualTools::publishTrajectoryPath(const moveit_msgs::RobotTrajectory& trajectory_msg,


### PR DESCRIPTION
When visualizing trajectories of subgroups the previous implementation would use the shared initial robot state for populating the joint values outside the group. This can have strange effects like apparent link collisions even though the original trajectory is collision free. If we have a robot trajectory with fully populated robot states we should use these instead.