### PR TITLE
[WIP] Unified collision environment

### DIFF
--- a/src/imarker_end_effector.cpp
+++ b/src/imarker_end_effector.cpp
@@ -284,7 +284,7 @@ bool isStateValid(const planning_scene::PlanningScene* planning_scene, bool verb
   robot_state->update();
 
 #if 0  // Ensure there are objects in the planning scene
-  const std::size_t num_collision_objects = planning_scene->getCollisionWorld()->getWorld()->size();
+  const std::size_t num_collision_objects = planning_scene->getCollisionEnv()->getWorld()->size();
   if (num_collision_objects == 0)
   {
     ROS_ERROR_STREAM_NAMED("cart_path_planner", "No collision objects exist in world, you need at least a table "

--- a/src/imarker_robot_state.cpp
+++ b/src/imarker_robot_state.cpp
@@ -342,7 +342,7 @@ bool isIKStateValid(const planning_scene::PlanningScene* planning_scene, bool ve
   robot_state->update();
 
 #if 0  // Ensure there are objects in the planning scene
-  const std::size_t num_collision_objects = planning_scene->getCollisionWorld()->getWorld()->size();
+  const std::size_t num_collision_objects = planning_scene->getCollisionEnv()->getWorld()->size();
   if (num_collision_objects == 0)
   {
     ROS_ERROR_STREAM_NAMED("imarker_robot_state", "No collision objects exist in world, you need at least a table "


### PR DESCRIPTION
This PR adapts the visual tools for the unified collision environment as proposed [here](https://github.com/ros-planning/moveit/pull/1584). It changes `getCollisionWorld` to the new `getCollisionEnv` function.

This does not build as the main unified PR has to be merged together with this.