### PR TITLE
Update hideRobot to hide visualized robot state by setting hide_display in DisplayRobotState msg

### DIFF
--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -1529,7 +1529,7 @@ bool MoveItVisualTools::hideRobot()
 {
   moveit_msgs::DisplayRobotState display_robot_state_msg;
   // Hide the robot state
-  display_robot_state_msg.hide_display = true;
+  display_robot_state_msg.hide = true;
 
   // Publish
   publishRobotState(display_robot_state_msg);

--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -1517,7 +1517,7 @@ void MoveItVisualTools::publishRobotState(const moveit_msgs::DisplayRobotState& 
   ros::spinOnce();
 }
 
-void MoveItVisualTools::hideRobot()
+bool MoveItVisualTools::hideRobot()
 {
   moveit_msgs::DisplayRobotState display_robot_state_msg;
   // Hide the robot state
@@ -1525,6 +1525,7 @@ void MoveItVisualTools::hideRobot()
 
   // Publish
   publishRobotState(display_robot_state_msg);
+  return true;
 }
 
 void MoveItVisualTools::showJointLimits(const robot_state::RobotStatePtr& robot_state)

--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -1517,22 +1517,14 @@ void MoveItVisualTools::publishRobotState(const moveit_msgs::DisplayRobotState& 
   ros::spinOnce();
 }
 
-bool MoveItVisualTools::hideRobot()
+void MoveItVisualTools::hideRobot()
 {
-  static const std::string VJOINT_NAME = "virtual_joint";
-
-  // Always load the robot state before using
-  loadSharedRobotState();
-
-  // Apply transform
-  Eigen::Isometry3d offset;
-  offset.translation().x() = rviz_visual_tools::LARGE_SCALE;
-  offset.translation().y() = rviz_visual_tools::LARGE_SCALE;
-  offset.translation().z() = rviz_visual_tools::LARGE_SCALE;
-  applyVirtualJointTransform(*hidden_robot_state_, offset);
+  moveit_msgs::DisplayRobotState display_robot_state_msg;
+  // Hide the robot state
+  display_robot_state_msg.hide_display = true;
 
   // Publish
-  return publishRobotState(hidden_robot_state_);
+  publishRobotState(display_robot_state_msg);
 }
 
 void MoveItVisualTools::showJointLimits(const robot_state::RobotStatePtr& robot_state)


### PR DESCRIPTION
This pull request should fix #52 after [pull request #55](https://github.com/ros-planning/moveit_msgs/pull/55) get merged.

@davetcoleman 
@henningkayser 