### PR TITLE
Drop melodic + kinetic support for master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ env:
   matrix:
     - TEST="clang-format catkin_lint"
     - TEST=clang-tidy-fix
-    - DOCKER_IMAGE=moveit/moveit:melodic-source
     - DOCKER_IMAGE=moveit/moveit:master-source
-    - DOCKER_IMAGE=moveit/moveit:kinetic-ci  UPSTREAM_WORKSPACE=moveit.rosinstall  TEST_BLACKLIST=moveit_ros_perception
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci


### PR DESCRIPTION
Alternative to #57: Due to incompatible `moveit_msgs`, the master branch cannot compile on Kinetic and Melodic anymore.