### PR TITLE
add tf_conversions as a dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   visualization_msgs
   graph_msgs
   std_msgs
+  tf_conversions
   trajectory_msgs
   cmake_modules
   roslint
@@ -37,6 +38,7 @@ catkin_package(
     visualization_msgs
     graph_msgs
     std_msgs
+    tf_conversions
     trajectory_msgs
   INCLUDE_DIRS include
 )

--- a/package.xml
+++ b/package.xml
@@ -29,5 +29,6 @@
   <depend>trajectory_msgs</depend>
   <depend>roslint</depend>
   <depend>cmake_modules</depend>
+  <depend>tf_conversions</depend>
 
 </package>


### PR DESCRIPTION
I get this error when I build master, I'm hoping this fixes that:

```
Errors     << moveit_visual_tools:make /root/upstream_ws/logs/moveit_visual_tools/build.make.000.log
/root/upstream_ws/src/moveit_visual_tools/src/imarker_end_effector.cpp:47:10: fatal error: tf_conversions/tf_eigen.h: No such file or directory
 #include <tf_conversions/tf_eigen.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/moveit_visual_tools.dir/src/imarker_end_effector.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/moveit_visual_tools.dir/all] Error 2
make: *** [all] Error 2
cd /root/upstream_ws/build/moveit_visual_tools; catkin build --get-env moveit_visual_tools | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
```

I see the other pr to replace tf_conversions... but until that lands it should be listed as a dependency.