### PR TITLE
provide a parameter-less constructor for new users

### DIFF
--- a/include/moveit_visual_tools/moveit_visual_tools.h
+++ b/include/moveit_visual_tools/moveit_visual_tools.h
@@ -78,6 +78,14 @@ class MoveItVisualTools : public rviz_visual_tools::RvizVisualTools
 public:
   /**
    * \brief Constructor
+   *
+   * All Markers will be rendered in the planning frame of the model ROBOT_DESCRIPTION
+   * and are published to rviz_visual_tools::RVIZ_MARKER_TOPIC
+   */
+  MoveItVisualTools();
+
+  /**
+   * \brief Constructor
    * \param base_frame - common base for all visualization markers, usually "/world" or "/odom"
    * \param marker_topic - rostopic to publish markers to - your Rviz display should match
    * \param planning_scene_monitor - optionally pass in a pre-loaded planning scene monitor to

--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -67,6 +67,15 @@ namespace moveit_visual_tools
 {
 const std::string LOGNAME = "visual_tools";
 
+MoveItVisualTools::MoveItVisualTools()
+  : RvizVisualTools("", rviz_visual_tools::RVIZ_MARKER_TOPIC)
+  , robot_state_topic_(DISPLAY_ROBOT_STATE_TOPIC)
+  , planning_scene_topic_(PLANNING_SCENE_TOPIC)
+{
+  loadSharedRobotState();
+  setBaseFrame(robot_model_->getModelFrame());
+}
+
 MoveItVisualTools::MoveItVisualTools(const std::string& base_frame, const std::string& marker_topic,
                                      planning_scene_monitor::PlanningSceneMonitorPtr psm)
   : RvizVisualTools::RvizVisualTools(base_frame, marker_topic)


### PR DESCRIPTION
Sadly, MoveItVisualTools(std::string) is already defined and
requires a *base_link*. In my opinion rather unfortunate, because the
topic seems much more likely to change, but that's what we got.
Instead, I opted for a constructor with hard-coded topic name.
Experienced users that need to change the topic should already know
the name of their base link.

Makes sense to backport to `melodic-devel`.

Fixes #23