### PR TITLE
[master] Adding missing dependency (interactive_markers)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
   trajectory_msgs
   cmake_modules
   roslint
+  interactive_markers
 )
 
 find_package(Eigen3 REQUIRED)
@@ -38,6 +39,7 @@ catkin_package(
     graph_msgs
     std_msgs
     trajectory_msgs
+    interactive_markers
   INCLUDE_DIRS include
 )
 

--- a/package.xml
+++ b/package.xml
@@ -29,5 +29,6 @@
   <depend>trajectory_msgs</depend>
   <depend>roslint</depend>
   <depend>cmake_modules</depend>
+  <depend>interactive_markers</depend>
 
 </package>


### PR DESCRIPTION
In https://github.com/ros-planning/moveit_visual_tools/blob/master/src/imarker_robot_state.cpp, there are many references to `interactive_markers`. However, this immediate dependency is not declared in the package. I am adding this to avoid potential build break.

I am motivated by a build break found with the `noetic\2020-08-31` release sync with `moveit_visual_tools` on Windows. I am using `colcon build`, and which did an isolated build.

```
   Creating library devel\lib\moveit_visual_tools.lib and object devel\lib\moveit_visual_tools.exp
imarker_robot_state.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: __cdecl interactive_markers::InteractiveMarkerServer::InteractiveMarkerServer(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,bool)" (__imp_??0InteractiveMarkerServer@interactive_markers@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0_N@Z) referenced in function "void __cdecl std::_Construct_in_place<class interactive_markers::InteractiveMarkerServer,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,char const (&)[1],bool>(class interactive_markers::InteractiveMarkerServer &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,char const (&)[1],bool &&)" (??$_Construct_in_place@VInteractiveMarkerServer@interactive_markers@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEAY00$$CBD_N@std@@YAXAEAVInteractiveMarkerServer@interactive_markers@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@0@AEAY00$$CBD$$QEA_N@Z)
imarker_robot_state.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: __cdecl interactive_markers::InteractiveMarkerServer::~InteractiveMarkerServer(void)" (__imp_??1InteractiveMarkerServer@interactive_markers@@QEAA@XZ) referenced in function "void __cdecl std::_Destroy_in_place<class interactive_markers::InteractiveMarkerServer>(class interactive_markers::InteractiveMarkerServer &)" (??$_Destroy_in_place@VInteractiveMarkerServer@interactive_markers@@@std@@YAXAEAVInteractiveMarkerServer@interactive_markers@@@Z)
imarker_robot_state.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: void __cdecl interactive_markers::InteractiveMarkerServer::applyChanges(void)" (__imp_?applyChanges@InteractiveMarkerServer@interactive_markers@@QEAAXXZ) referenced in function "public: __cdecl moveit_visual_tools::IMarkerRobotState::IMarkerRobotState(class std::shared_ptr<class planning_scene_monitor::PlanningSceneMonitor>,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::vector<struct moveit_visual_tools::ArmData,class std::allocator<struct moveit_visual_tools::ArmData> >,enum rviz_visual_tools::colors,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (??0IMarkerRobotState@moveit_visual_tools@@QEAA@V?$shared_ptr@VPlanningSceneMonitor@planning_scene_monitor@@@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@V?$vector@UArmData@moveit_visual_tools@@V?$allocator@UArmData@moveit_visual_tools@@@std@@@3@W4colors@rviz_visual_tools@@1@Z)
imarker_end_effector.cpp.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: void __cdecl interactive_markers::InteractiveMarkerServer::applyChanges(void)" (__imp_?applyChanges@InteractiveMarkerServer@interactive_markers@@QEAAXXZ)
imarker_end_effector.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: void __cdecl interactive_markers::InteractiveMarkerServer::insert(struct visualization_msgs::InteractiveMarker_<class std::allocator<void> > const &)" (__imp_?insert@InteractiveMarkerServer@interactive_markers@@QEAAXAEBU?$InteractiveMarker_@V?$allocator@X@std@@@visualization_msgs@@@Z) referenced in function "public: void __cdecl moveit_visual_tools::IMarkerEndEffector::make6DofMarker(struct geometry_msgs::Pose_<class std::allocator<void> > const &)" (?make6DofMarker@IMarkerEndEffector@moveit_visual_tools@@QEAAXAEBU?$Pose_@V?$allocator@X@std@@@geometry_msgs@@@Z)
imarker_end_effector.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: bool __cdecl interactive_markers::InteractiveMarkerServer::setPose(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,struct geometry_msgs::Pose_<class std::allocator<void> > const &,struct std_msgs::Header_<class std::allocator<void> > const &)" (__imp_?setPose@InteractiveMarkerServer@interactive_markers@@QEAA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBU?$Pose_@V?$allocator@X@std@@@geometry_msgs@@AEBU?$Header_@V?$allocator@X@std@@@std_msgs@@@Z) referenced in function "public: void __cdecl moveit_visual_tools::IMarkerEndEffector::sendUpdatedIMarkerPose(void)" (?sendUpdatedIMarkerPose@IMarkerEndEffector@moveit_visual_tools@@QEAAXXZ)
imarker_end_effector.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: bool __cdecl interactive_markers::InteractiveMarkerServer::setCallback(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class boost::function<void __cdecl(class boost::shared_ptr<struct visualization_msgs::InteractiveMarkerFeedback_<class std::allocator<void> > const > const &)>,unsigned char)" (__imp_?setCallback@InteractiveMarkerServer@interactive_markers@@QEAA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$function@$$A6AXAEBV?$shared_ptr@$$CBU?$InteractiveMarkerFeedback_@V?$allocator@X@std@@@visualization_msgs@@@boost@@@Z@boost@@E@Z) referenced in function "public: void __cdecl moveit_visual_tools::IMarkerEndEffector::make6DofMarker(struct geometry_msgs::Pose_<class std::allocator<void> > const &)" (?make6DofMarker@IMarkerEndEffector@moveit_visual_tools@@QEAAXAEBU?$Pose_@V?$allocator@X@std@@@geometry_msgs@@@Z)
devel\bin\moveit_visual_tools.dll : fatal error LNK1120: 6 unresolved externals
ninja: build stopped: subcommand failed.

```