### PR TITLE
fix end-effectors containing mimic joints

### DIFF
--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -270,7 +270,12 @@ bool MoveItVisualTools::loadEEMarker(const moveit::core::JointModelGroup* ee_jmg
                                           << ee_jmg->getName() << "(" << ee_jmg->getActiveJointModels().size() << ")");
       return false;
     }
-    shared_robot_state_->setJointGroupPositions(ee_jmg, ee_joint_pos);
+    std::size_t i = 0;
+    for (auto& joint : ee_jmg->getActiveJointModels())
+    {
+      shared_robot_state_->setJointPositions(joint, &ee_joint_pos[i]);
+      ++i;  // Note that joints with more than one variable will be rejected above
+    }
     shared_robot_state_->update(true);
   }
 


### PR DESCRIPTION
This fixes #82 

I'd prefer to actually add this as a new method in `RobotState` and use it here. However to simplify backporting, I created this simple fix as well. Should be backported to `melodic-devel` as well as `noetic-devel` as it could potentially lead to crashes due to accessing out-of-bounds memory (and confusion due to joint being displayed at random/zero positions)