### PR TITLE
fix end-effectors containing mimic joints v2

### DIFF
--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -270,7 +270,7 @@ bool MoveItVisualTools::loadEEMarker(const moveit::core::JointModelGroup* ee_jmg
                                           << ee_jmg->getName() << "(" << ee_jmg->getActiveJointModels().size() << ")");
       return false;
     }
-    shared_robot_state_->setJointGroupPositions(ee_jmg, ee_joint_pos);
+    shared_robot_state_->setJointGroupActivePositions(ee_jmg, ee_joint_pos);
     shared_robot_state_->update(true);
   }
 


### PR DESCRIPTION
this is an iteration on #83 based on the new function `JointModelGroup::setJointGroupActivePositions` introduced by https://github.com/ros-planning/moveit/pull/2456

It fixes #82 