### PR TITLE
use specified color_ for EndEffector marker

### DIFF
--- a/include/moveit_visual_tools/imarker_end_effector.h
+++ b/include/moveit_visual_tools/imarker_end_effector.h
@@ -76,7 +76,7 @@ public:
    * \brief Constructor
    */
   IMarkerEndEffector(IMarkerRobotState* imarker_parent, const std::string& imarker_name, ArmData arm_data,
-                     rviz_visual_tools::colors color);
+                     rviz_visual_tools::colors color = rviz_visual_tools::PURPLE);
 
   ~IMarkerEndEffector()
   {
@@ -147,7 +147,7 @@ private:
 
   // Settings
   ArmData arm_data_;
-  rviz_visual_tools::colors color_ = rviz_visual_tools::PURPLE;
+  rviz_visual_tools::colors color_;
 
   // File saving
   ros::Time time_since_last_save_;

--- a/src/imarker_end_effector.cpp
+++ b/src/imarker_end_effector.cpp
@@ -312,10 +312,7 @@ IMarkerEndEffector::makeBoxControl(visualization_msgs::InteractiveMarker& msg)
   marker.scale.x = msg.scale * 0.3;   // x direction
   marker.scale.y = msg.scale * 0.10;  // y direction
   marker.scale.z = msg.scale * 0.10;  // height
-  marker.color.r = 0.5;
-  marker.color.g = 0.5;
-  marker.color.b = 0.5;
-  marker.color.a = 1.0;
+  marker.color = visual_tools_->getColor(color_);
 
   control.markers.push_back(marker);
   msg.controls.push_back(control);


### PR DESCRIPTION
Related to https://github.com/ros-planning/moveit/pull/2792 .

Addresses this clang warning

<<<
moveit_visual_tools/include/moveit_visual_tools/imarker_end_effector.h:150:29: error: private field 'color_' is not used [-Werror,-Wunused-private-field]
  rviz_visual_tools::colors color_ = rviz_visual_tools::PURPLE;
                            ^
1 error generated.
>>>

We could have removed the member just as well (it barely matters...),
but that would entail an unnecessary API change in the constructor.

I added the default value for the constructor parameter as it is always overwritten until now...