### PR TITLE
Don't export moveit_visual_tools_demo as a dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,13 +66,18 @@ ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ## Install ##
 #############
 
-# Install libraries and executables
+# Install libraries
 install(
-  TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_demo
+  TARGETS ${PROJECT_NAME}
   EXPORT
     export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
+)
+
+# Install executables
+install(
+  TARGETS ${PROJECT_NAME}_demo
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 


### PR DESCRIPTION
When i include **moveit_visual_tools** as a dependency (in particular as a dependency of **movit2_tutorials**), cmake complains about  not finding the library `moveit_visual_tools_demo`.

This should fix the issue.