### PR TITLE
Update rviz_visual_tools branch

### DIFF
--- a/moveit_visual_tools.repos
+++ b/moveit_visual_tools.repos
@@ -2,7 +2,7 @@ repositories:
   rviz_visual_tools:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools
-    version: foxy-devel
+    version: ros2
   graph_msgs:
     type: git
     url: https://github.com/PickNikRobotics/graph_msgs


### PR DESCRIPTION
We should use ros2 branch of rviz_visual_tools in ros2 branch of mvt and open a foxy branch for mvt that depends on foxy branch of rvt.