### PR TITLE
[master] Update black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
 


### PR DESCRIPTION
Running pre-commit with the current black version is broken, and should be updated as per https://github.com/ros-planning/moveit2/pull/1148