### PR TITLE
Return error in publishTrajectoryLine if no end-effectors are defined

### DIFF
--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -1383,10 +1383,23 @@ bool MoveItVisualTools::publishTrajectoryLine(const moveit_msgs::msg::RobotTraje
                                               const moveit::core::JointModelGroup* arm_jmg,
                                               const rviz_visual_tools::Colors& color)
 {
+  if (!arm_jmg)
+  {
+    RCLCPP_FATAL_STREAM(LOGGER, "arm_jmg is NULL");
+    return false;
+  }
+
   std::vector<const moveit::core::LinkModel*> tips;
-  if (!arm_jmg->getEndEffectorTips(tips))
+  bool tips_ok = arm_jmg->getEndEffectorTips(tips);
+  if (!tips_ok)
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Unable to get end effector tips from jmg");
+    return false;
+  }
+  if (tips.empty())
+  {
+    RCLCPP_WARN_STREAM(LOGGER, "Can't create trajectory line because the group '" << arm_jmg->getName()
+                                                                                  << "' doesn't define end-effectors");
     return false;
   }
 
@@ -1411,10 +1424,23 @@ bool MoveItVisualTools::publishTrajectoryLine(const robot_trajectory::RobotTraje
                                               const moveit::core::JointModelGroup* arm_jmg,
                                               const rviz_visual_tools::Colors& color)
 {
+  if (!arm_jmg)
+  {
+    RCLCPP_FATAL_STREAM(LOGGER, "arm_jmg is NULL");
+    return false;
+  }
+
   std::vector<const moveit::core::LinkModel*> tips;
-  if (!arm_jmg->getEndEffectorTips(tips))
+  bool tips_ok = arm_jmg->getEndEffectorTips(tips);
+  if (!tips_ok)
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Unable to get end effector tips from jmg");
+    return false;
+  }
+  if (tips.empty())
+  {
+    RCLCPP_WARN_STREAM(LOGGER, "Can't create trajectory line because the group '" << arm_jmg->getName()
+                                                                                  << "' doesn't define end-effectors");
     return false;
   }
 

--- a/src/moveit_visual_tools.cpp
+++ b/src/moveit_visual_tools.cpp
@@ -1390,16 +1390,9 @@ bool MoveItVisualTools::publishTrajectoryLine(const moveit_msgs::msg::RobotTraje
   }
 
   std::vector<const moveit::core::LinkModel*> tips;
-  bool tips_ok = arm_jmg->getEndEffectorTips(tips);
-  if (!tips_ok)
+  if (!arm_jmg->getEndEffectorTips(tips) || tips.empty())
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Unable to get end effector tips from jmg");
-    return false;
-  }
-  if (tips.empty())
-  {
-    RCLCPP_WARN_STREAM(LOGGER, "Can't create trajectory line because the group '" << arm_jmg->getName()
-                                                                                  << "' doesn't define end-effectors");
     return false;
   }
 
@@ -1431,16 +1424,9 @@ bool MoveItVisualTools::publishTrajectoryLine(const robot_trajectory::RobotTraje
   }
 
   std::vector<const moveit::core::LinkModel*> tips;
-  bool tips_ok = arm_jmg->getEndEffectorTips(tips);
-  if (!tips_ok)
+  if (!arm_jmg->getEndEffectorTips(tips) || tips.empty())
   {
     RCLCPP_ERROR_STREAM(LOGGER, "Unable to get end effector tips from jmg");
-    return false;
-  }
-  if (tips.empty())
-  {
-    RCLCPP_WARN_STREAM(LOGGER, "Can't create trajectory line because the group '" << arm_jmg->getName()
-                                                                                  << "' doesn't define end-effectors");
     return false;
   }
 


### PR DESCRIPTION
If a joint model group doesn't define an end-effector, 'publishTrajectoryLine' can't create and publish the markers. But it would still succeed. This change adds a check for missing end-effectors, logs a warning and returns false, since markers can't be published.