### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PUBLIC $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(${PROJECT_NAME} PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${geometry_msgs_TARGETS} ${std_msgs_TARGETS} ${trajectory_msgs_TARGETS} ${visualization_msgs_TARGETS} moveit_core::moveit_collision_detection moveit_ros_planning::kinematics_parameters moveit_ros_planning::moveit_collision_plugin_loader rclcpp::rclcpp tf2_eigen::tf2_eigen tf2_ros::tf2_ros)
 
 # Demo executable
 add_executable(${PROJECT_NAME}_demo
@@ -54,7 +54,7 @@ add_executable(${PROJECT_NAME}_demo
 )
 target_link_libraries(${PROJECT_NAME}_demo
   ${PROJECT_NAME}
-  PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+PUBLIC ${geometry_msgs_TARGETS} ${std_msgs_TARGETS} ${trajectory_msgs_TARGETS} ${visualization_msgs_TARGETS} moveit_core::moveit_collision_detection moveit_ros_planning::kinematics_parameters moveit_ros_planning::moveit_collision_plugin_loader rclcpp::rclcpp tf2_eigen::tf2_eigen tf2_ros::tf2_ros
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,8 @@ add_executable(${PROJECT_NAME}_demo
 )
 target_link_libraries(${PROJECT_NAME}_demo
   ${PROJECT_NAME}
+  PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 )
-target_link_libraries(${PROJECT_NAME}_demo PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 
 # Exports

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PUBLIC $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Demo executable
 add_executable(${PROJECT_NAME}_demo
@@ -55,7 +55,7 @@ add_executable(${PROJECT_NAME}_demo
 target_link_libraries(${PROJECT_NAME}_demo
   ${PROJECT_NAME}
 )
-ament_target_dependencies(${PROJECT_NAME}_demo ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(${PROJECT_NAME}_demo PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 
 # Exports


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
