### PR TITLE
CMake: drop boost system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(moveit_common REQUIRED)
 moveit_package()
 
 # Load  all dependencies required for this package
-find_package(Boost REQUIRED system)
+find_package(Boost REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(graph_msgs REQUIRED)


### PR DESCRIPTION
Hi,

This fix for boost >= 1.89:
```cmake
CMake Error at /nix/store/4qaj1kkf1p3al8z190px12ma6r8jbgqj-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake

  Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
  "boost_system_DIR" to a directory containing one of the above files.  If
  "boost_system" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /nix/store/4qaj1kkf1p3al8z190px12ma6r8jbgqj-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:262 (boost_find_component)
  /nix/store/v2i1hgv567g3v91im5x4g5bff52143i0-cmake-4.1.2/share/cmake-4.1/Modules/FindBoost.cmake:609 (find_package)
  CMakeLists.txt:8 (find_package)

-- Configuring incomplete, errors occurred!
```

boost system has been header only since release 1.69 (December 5, 2018), and a useless stub was provided instead.

in 1.89 (August 6, 2025), that stub was removed, so CMake fail if we require it.

ref. https://www.boost.org/doc/libs/latest/libs/system/doc/html/system.html#changes_in_boost_1_89