### PR TITLE
Fix Rolling build: replace ament_target_dependencies + guard the ament_index_cpp header rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(${PROJECT_NAME}
     moveit_core::moveit_robot_state
     moveit_core::moveit_utils
     ${moveit_msgs_TARGETS}
-    moveit_ros_planning::moveit_ros_planning
+    moveit_ros_planning::moveit_planning_scene_monitor
     rclcpp::rclcpp
     rviz_visual_tools::rviz_visual_tools
     interactive_markers::interactive_markers
@@ -90,7 +90,7 @@ target_link_libraries(${PROJECT_NAME}_demo
   moveit_core::moveit_robot_state
   moveit_core::moveit_utils
   ${moveit_msgs_TARGETS}
-  moveit_ros_planning::moveit_ros_planning
+  moveit_ros_planning::moveit_planning_scene_monitor
   rclcpp::rclcpp
   rviz_visual_tools::rviz_visual_tools
   interactive_markers::interactive_markers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,14 @@ find_package(moveit_common REQUIRED)
 moveit_package()
 
 # Load  all dependencies required for this package
+find_package(ament_index_cpp REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(geometric_shapes REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(graph_msgs REQUIRED)
 find_package(moveit_core REQUIRED)
+find_package(moveit_msgs REQUIRED)
 find_package(moveit_ros_planning REQUIRED)
 find_package(moveit_ros_occupancy_map_monitor REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -27,6 +30,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   geometry_msgs
   graph_msgs
   moveit_core
+  moveit_msgs
   moveit_ros_planning
   rclcpp
   rviz_visual_tools
@@ -50,20 +54,28 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(${PROJECT_NAME}
-  ${geometry_msgs_TARGETS}
-  ${graph_msgs_TARGETS}
-  moveit_core::moveit_robot_state
-  moveit_core::moveit_utils
-  moveit_ros_planning::moveit_ros_planning
-  rclcpp::rclcpp
-  rviz_visual_tools::rviz_visual_tools
-  interactive_markers::interactive_markers
-  ${std_msgs_TARGETS}
-  tf2_eigen::tf2_eigen
-  tf2_ros::tf2_ros
-  ${trajectory_msgs_TARGETS}
-  ${visualization_msgs_TARGETS}
-  ${Boost_LIBRARIES}
+  PUBLIC
+    ${geometry_msgs_TARGETS}
+    ${graph_msgs_TARGETS}
+    moveit_core::moveit_robot_state
+    moveit_core::moveit_utils
+    ${moveit_msgs_TARGETS}
+    moveit_ros_planning::moveit_ros_planning
+    rclcpp::rclcpp
+    rviz_visual_tools::rviz_visual_tools
+    interactive_markers::interactive_markers
+    ${std_msgs_TARGETS}
+    tf2_eigen::tf2_eigen
+    tf2_ros::tf2_ros
+    ${trajectory_msgs_TARGETS}
+    ${visualization_msgs_TARGETS}
+    ${Boost_LIBRARIES}
+  # Implementation-only: included by src/moveit_visual_tools.cpp and absent from
+  # every public header, so it is kept out of the exported interface and out of
+  # THIS_PACKAGE_INCLUDE_DEPENDS. This is a SHARED library, so a PRIVATE link is
+  # not re-exported at all -- downstream consumers do not need geometric_shapes.
+  PRIVATE
+    geometric_shapes::geometric_shapes
 )
 
 # Demo executable
@@ -72,10 +84,12 @@ add_executable(${PROJECT_NAME}_demo
 )
 target_link_libraries(${PROJECT_NAME}_demo
   ${PROJECT_NAME}
+  ament_index_cpp::ament_index_cpp
   ${geometry_msgs_TARGETS}
   ${graph_msgs_TARGETS}
   moveit_core::moveit_robot_state
   moveit_core::moveit_utils
+  ${moveit_msgs_TARGETS}
   moveit_ros_planning::moveit_ros_planning
   rclcpp::rclcpp
   rviz_visual_tools::rviz_visual_tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(moveit_ros_occupancy_map_monitor REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rviz_visual_tools REQUIRED)
+find_package(interactive_markers REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_ros REQUIRED)
@@ -29,6 +30,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_ros_planning
   rclcpp
   rviz_visual_tools
+  interactive_markers
   std_msgs
   tf2_eigen
   tf2_ros
@@ -47,7 +49,22 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PUBLIC $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(${PROJECT_NAME}
+  ${geometry_msgs_TARGETS}
+  ${graph_msgs_TARGETS}
+  moveit_core::moveit_robot_state
+  moveit_core::moveit_utils
+  moveit_ros_planning::moveit_ros_planning
+  rclcpp::rclcpp
+  rviz_visual_tools::rviz_visual_tools
+  interactive_markers::interactive_markers
+  ${std_msgs_TARGETS}
+  tf2_eigen::tf2_eigen
+  tf2_ros::tf2_ros
+  ${trajectory_msgs_TARGETS}
+  ${visualization_msgs_TARGETS}
+  ${Boost_LIBRARIES}
+)
 
 # Demo executable
 add_executable(${PROJECT_NAME}_demo
@@ -55,8 +72,21 @@ add_executable(${PROJECT_NAME}_demo
 )
 target_link_libraries(${PROJECT_NAME}_demo
   ${PROJECT_NAME}
+  ${geometry_msgs_TARGETS}
+  ${graph_msgs_TARGETS}
+  moveit_core::moveit_robot_state
+  moveit_core::moveit_utils
+  moveit_ros_planning::moveit_ros_planning
+  rclcpp::rclcpp
+  rviz_visual_tools::rviz_visual_tools
+  interactive_markers::interactive_markers
+  ${std_msgs_TARGETS}
+  tf2_eigen::tf2_eigen
+  tf2_ros::tf2_ros
+  ${trajectory_msgs_TARGETS}
+  ${visualization_msgs_TARGETS}
+  ${Boost_LIBRARIES}
 )
-ament_target_dependencies(${PROJECT_NAME}_demo ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 
 # Exports

--- a/package.xml
+++ b/package.xml
@@ -16,10 +16,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
+  <depend>geometric_shapes</depend>
   <depend>geometry_msgs</depend>
   <depend>graph_msgs</depend>
   <depend>moveit_common</depend>
   <depend>moveit_core</depend>
+  <depend>moveit_msgs</depend>
   <depend>moveit_ros_planning</depend>
   <depend>rclcpp</depend>
   <depend>rviz_visual_tools</depend>

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <depend>moveit_ros_planning</depend>
   <depend>rclcpp</depend>
   <depend>rviz_visual_tools</depend>
+  <depend>interactive_markers</depend>
   <depend>std_msgs</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>

--- a/src/moveit_visual_tools_demo.cpp
+++ b/src/moveit_visual_tools_demo.cpp
@@ -33,7 +33,13 @@
 
 // ROS
 #include <rclcpp/rclcpp.hpp>
+#include <ament_index_cpp/version.h>
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+#include <ament_index_cpp/get_package_share_path.hpp>
+#include <filesystem>
+#else
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#endif
 
 // For visualizing things in rviz
 #include <moveit_visual_tools/moveit_visual_tools.h>
@@ -204,8 +210,12 @@ public:
 
     // --------------------------------------------------------------------
     RCLCPP_INFO_STREAM(LOGGER, "Publishing Collision Mesh");
-    // TODO: Catch exception
+// TODO: Catch exception
+#if AMENT_INDEX_CPP_VERSION_GTE(1, 14, 0)
+    std::string file_path = "file://" + ament_index_cpp::get_package_share_path(THIS_PACKAGE).string();
+#else
     std::string file_path = "file://" + ament_index_cpp::get_package_share_directory(THIS_PACKAGE);
+#endif
     if (file_path == "file://")
       RCLCPP_FATAL_STREAM(LOGGER, "Unable to get " << THIS_PACKAGE << " package path ");
     file_path.append("/resources/demo_mesh.stl");


### PR DESCRIPTION
Addresses

## 1. `ament_target_dependencies` was removed

From (ament/ament_cmake#614, merged 2026-01-13). Migrated the library and demo targets to `target_link_libraries` with imported targets.

## 2. `ament_index_cpp` 1.14 removed `<get_package_share_directory.hpp>`

`moveit_visual_tools_demo.cpp` now selects `get_package_share_path` (returns `std::filesystem::path`) when available and falls back otherwise, keyed on `AMENT_INDEX_CPP_VERSION_GTE` — the carrier package's own version macro, not `RCLCPP_VERSION_GTE`.

Inspired by
- moveit/moveit2#3726
- moveit/moveit2#3705
- PickNikRobotics/rviz_visual_tools#277 